### PR TITLE
Feat: Global onchange

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -53,10 +53,15 @@ const createStore = (initialState, onChangeCallback = () => {}) => {
   const setCurrentState = newState => currentState = newState
   const setUpdater = updaterFunction => updater = updaterFunction
 
-  const commit = (type, payload, callback = () => {}) => {
-    currentState = updater({...currentState, primaryUpdate: {type, payload: {...payload, uid: makeUid()}}})
-    callback(currentState)
-    onChangeCallback({ type, state: currentState })
+  const commit = (type, payload, meta = {}) => {
+    currentState = updater({
+      ...currentState,
+      primaryUpdate: {
+        type,
+        payload: { ...payload, uid: makeUid()}
+      }
+    })
+    if (!meta.silent) onChangeCallback({ type, state: currentState }, meta)
   }
 
   const dispatch = (type, payload) => setTimeout(() => commit(type, payload))


### PR DESCRIPTION
Adds a new argument to `state.createStore` that allows the instance to have a global callback on any aeroelastic state updates.

This is a breaking change, as it also removes the commit callback and replaces it with a meta object that can be used to skip the global change callback.